### PR TITLE
Fix invalid typescript syntax.

### DIFF
--- a/services/iam/v3/model/ServiceStatement.ts
+++ b/services/iam/v3/model/ServiceStatement.ts
@@ -3,7 +3,7 @@
 export class ServiceStatement {
     private 'Action': Array<string> | undefined;
     private 'Effect': ServiceStatementEffectEnum | undefined;
-    private 'Condition'?: { [key: string]: { [key: string]: Array; }; } | undefined;
+    private 'Condition'?: { [key: string]: { [key: string]: Array<any>; }; } | undefined;
     private 'Resource'?: Array<string> | undefined;
     public constructor(action?: any, effect?: any) { 
         this['Action'] = action;
@@ -29,11 +29,11 @@ export class ServiceStatement {
     public get effect() {
         return this['Effect'];
     }
-    public withCondition(condition: { [key: string]: { [key: string]: Array; }; }): ServiceStatement {
+    public withCondition(condition: { [key: string]: { [key: string]: Array<any>; }; }): ServiceStatement {
         this['Condition'] = condition;
         return this;
     }
-    public set condition(condition: { [key: string]: { [key: string]: Array; }; } | undefined) {
+    public set condition(condition: { [key: string]: { [key: string]: Array<any>; }; } | undefined) {
         this['Condition'] = condition;
     }
     public get condition() {


### PR DESCRIPTION
I was getting this error when trying to use the node package: 
```

node_modules/@huaweicloud/huaweicloud-sdk-iam/v3/model/ServiceStatement.d.ts:15:28 - error TS2314: Generic type 'Array<T>' requires 1 type argument(s).

15             [key: string]: Array;
                              ~~~~~

node_modules/@huaweicloud/huaweicloud-sdk-iam/v3/model/ServiceStatement.d.ts:20:28 - error TS2314: Generic type 'Array<T>' requires 1 type argument(s).

20             [key: string]: Array;
                              ~~~~~

node_modules/@huaweicloud/huaweicloud-sdk-iam/v3/model/ServiceStatement.d.ts:25:28 - error TS2314: Generic type 'Array<T>' requires 1 type argument(s).

25             [key: string]: Array;
                              ~~~~~
```

I think you can't just use `Array;` without specifying a type. I fixed that using the type `any.`